### PR TITLE
add client code gen

### DIFF
--- a/__tests__/integration/index.ts
+++ b/__tests__/integration/index.ts
@@ -1,5 +1,8 @@
+import { DocumentType, graphql } from "src/gql";
 import request, { Response } from "supertest";
 import app from "../../src/webserver";
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
+import { HelloQuery } from "src/gql/graphql";
 
 const expectSuccessfulGraphQLResponse = (response: Response) => {
   expect(response.body.errors).toBeUndefined();
@@ -7,11 +10,15 @@ const expectSuccessfulGraphQLResponse = (response: Response) => {
 
 describe("Integration testing GraphQL API", () => {
   it("return 'hello GraphQL world' for hello query", async () => {
-    const helloQuery = /* GraphQL */ `
+    const helloQuery = /* GraphQL */ graphql(`
       query hello {
         hello
       }
-    `;
+    `);
+
+    //if your query had parameters the type would also be infered here.
+    const autoTypedResult = executeQuery(helloQuery, {});
+    (await autoTypedResult).hello;
 
     const createHelloQuery = () => {
       return {
@@ -28,14 +35,39 @@ describe("Integration testing GraphQL API", () => {
 
     expectSuccessfulGraphQLResponse(response);
 
-    // TODO: How can I use '@graphql-codegen/x' here to automatically create the
-    // correct typeing for my helloQuery?
+    
     type HelloQueryResult = {
-      data: {
-        hello: string;
-      };
+      data:  DocumentType<typeof helloQuery>;
     };
+    type HelloQueryResult2 = {
+      data: HelloQuery
+    }
     const result = response.body as HelloQueryResult;
+    const result2 = response.body as HelloQueryResult2;
     expect(result.data.hello).toBe("hello GraphQL world");
   });
 });
+
+
+async function executeQuery<
+  TQueryDocument extends TypedDocumentNode<any, any>, 
+  TResponseType = DocumentType<TQueryDocument>, 
+  TVariables = TQueryDocument extends TypedDocumentNode< any, infer TType>  ? TType  : never
+>(query: TQueryDocument, variables: TVariables): Promise<TResponseType> {
+
+  const createHelloQuery = () => {
+    return {
+      query: query,
+      variables: variables,
+    };
+  };
+
+  const response = await request(app)
+    .post("/graphql")
+    .set("Content-Type", "application/json")
+    .set("Accept", "application/json")
+    .send(createHelloQuery());
+
+  expectSuccessfulGraphQLResponse(response);
+  return response.body as TResponseType
+}

--- a/codegen.yml
+++ b/codegen.yml
@@ -1,7 +1,9 @@
 overwrite: true
 schema: "./src/schema.graphql"
-documents: "./src/operations/*.graphql"
+documents: ["./src/operations/*.graphql", "src/**/*.ts", "__tests__/**/*.ts"]
 generates:
+  ./src/gql/:
+    preset: 'client'
   ./src/generated-types.ts:
     plugins:
       - "typescript"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@babel/preset-typescript": "7.18.6",
     "@graphql-codegen/add": "3.2.3",
     "@graphql-codegen/cli": "2.16.4",
+    "@graphql-codegen/client-preset": "^1.2.6",
     "@graphql-codegen/typescript-resolvers": "2.7.12",
     "@types/express": "4.17.16",
     "@types/jest": "29.4.0",


### PR DESCRIPTION
I made a few examples of how you could get types from the query. I would go with the `executeQuery` function I made as it also types the variables that the query requires.